### PR TITLE
Fix for readVariable with drush 7+

### DIFF
--- a/src/Drupal/Variable/VariableStorage/Drush.php
+++ b/src/Drupal/Variable/VariableStorage/Drush.php
@@ -62,7 +62,7 @@ class Drush implements StorageInterface
      */
     public function readVariable($name, $default = null)
     {
-        $serialized = $this->execDrush("vget --format=php --exact " . escapeshellarg($name) . " 2>/dev/null");
+        $serialized = $this->execDrush("vget --format=php --exact --pipe " . escapeshellarg($name) . " 2>/dev/null");
         // Skip any SSH warnings, e.g.
         // Warning: Permanently added 'X.X.X.X' (RSA) to the list of known hosts.
         // TODO: how to improve this?


### PR DESCRIPTION
We were relying on a regression in Drush 6 for the output when reading variables, so bad things happen on Drush 7+.

Adding the --pipe option gives us the same output across all versions.
